### PR TITLE
feat(quiz): add MCQ quizzes with scoring + results (SQLite) 

### DIFF
--- a/models.py
+++ b/models.py
@@ -1,0 +1,45 @@
+from flask_sqlalchemy import SQLAlchemy
+from flask_login import UserMixin
+from werkzeug.security import generate_password_hash, check_password_hash
+
+db = SQLAlchemy()
+
+class User(UserMixin, db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    email = db.Column(db.String(255), unique=True, nullable=False)
+    password_hash = db.Column(db.String(255))
+    is_admin = db.Column(db.Boolean, default=False)
+
+    @staticmethod
+    def create_user(email: str, password: str, is_admin: bool = False):
+        u = User(email=email, is_admin=is_admin, password_hash=generate_password_hash(password))
+        db.session.add(u)
+        db.session.commit()
+        return u
+
+    def check_password(self, password: str) -> bool:
+        return check_password_hash(self.password_hash, password)
+
+class Quiz(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    title = db.Column(db.String(255))
+    topic = db.Column(db.String(255))
+    is_active = db.Column(db.Boolean, default=True)
+    questions = db.relationship('Question', backref='quiz', lazy=True)
+
+class Question(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    quiz_id = db.Column(db.Integer, db.ForeignKey('quiz.id'))
+    text = db.Column(db.Text)
+    option_a = db.Column(db.Text)
+    option_b = db.Column(db.Text)
+    option_c = db.Column(db.Text)
+    option_d = db.Column(db.Text)
+    correct = db.Column(db.String(1))  # A/B/C/D
+
+class Attempt(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id'))
+    quiz_id = db.Column(db.Integer, db.ForeignKey('quiz.id'))
+    score = db.Column(db.Integer)
+    total = db.Column(db.Integer)

--- a/routes/quiz.py
+++ b/routes/quiz.py
@@ -1,0 +1,51 @@
+from flask import Blueprint, render_template, redirect, url_for, request
+from flask_login import login_required, current_user
+from models import db, Quiz, Question, Attempt
+
+quiz_bp = Blueprint('quiz', __name__)
+
+def _seed_quiz_if_empty():
+    if Quiz.query.count() == 0:
+        qz = Quiz(title='Intro Quiz', topic='General')
+        db.session.add(qz); db.session.commit()
+        qs = [
+            Question(quiz_id=qz.id, text='What is AI?', option_a='Artificial Intelligence', option_b='Awesome Icecream', option_c='Air Intake', option_d='None', correct='A'),
+            Question(quiz_id=qz.id, text='RAG stands for?', option_a='Read-Answer-Generate', option_b='Retrieval-Augmented Generation', option_c='Random AI Guessing', option_d='Recurrent Agent Graph', correct='B'),
+        ]
+        db.session.add_all(qs); db.session.commit()
+
+@quiz_bp.get('/')
+@login_required
+def list_quizzes():
+    _seed_quiz_if_empty()
+    quizzes = Quiz.query.filter_by(is_active=True).all()
+    return render_template('quiz_list.html', quizzes=quizzes)
+
+@quiz_bp.get('/<int:quiz_id>')
+@login_required
+def take_quiz(quiz_id):
+    quiz = Quiz.query.get_or_404(quiz_id)
+    questions = Question.query.filter_by(quiz_id=quiz_id).all()
+    return render_template('quiz_take.html', quiz=quiz, questions=questions)
+
+@quiz_bp.post('/<int:quiz_id>/submit')
+@login_required
+def submit_quiz(quiz_id):
+    quiz = Quiz.query.get_or_404(quiz_id)
+    questions = Question.query.filter_by(quiz_id=quiz_id).all()
+    score = 0
+    for q in questions:
+        ans = request.form.get(f'q{q.id}')
+        if ans and ans.upper() == q.correct.upper():
+            score += 1
+    attempt = Attempt(user_id=current_user.id, quiz_id=quiz_id, score=score, total=len(questions))
+    db.session.add(attempt); db.session.commit()
+    return redirect(url_for('quiz.result', attempt_id=attempt.id))
+
+@quiz_bp.get('/result/<int:attempt_id>')
+@login_required
+def result(attempt_id):
+    attempt = Attempt.query.get_or_404(attempt_id)
+    quiz = Quiz.query.get_or_404(attempt.quiz_id)
+    return render_template('quiz_result.html', attempt=attempt, quiz=quiz)
+    

--- a/templates/quiz_list.html
+++ b/templates/quiz_list.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+{% block content %}
+<h2>Quizzes</h2>
+<ul class="list">
+  {% for q in quizzes %}
+    <li>
+      <strong>{{ q.title }}</strong> — {{ q.topic }}
+      <a class="btn btn-small" href="{{ url_for('quiz.take_quiz', quiz_id=q.id) }}">Take</a>
+    </li>
+  {% endfor %}
+</ul>
+{% endblock %}

--- a/templates/quiz_result.html
+++ b/templates/quiz_result.html
@@ -1,0 +1,7 @@
+{% extends "base.html" %}
+{% block content %}
+<h2>Result — {{ quiz.title }}</h2>
+<p>Your score: <strong>{{ attempt.score }}</strong> / {{ attempt.total }}</p>
+<a class="btn" href="{{ url_for('quiz.list_quizzes') }}">Back to Quizzes</a>
+<a class="btn" href="{{ url_for('dash.student_dashboard') }}">View Dashboard</a>
+{% endblock %}

--- a/templates/quiz_take.html
+++ b/templates/quiz_take.html
@@ -1,0 +1,16 @@
+{% extends "base.html" %}
+{% block content %}
+<h2>{{ quiz.title }} — {{ quiz.topic }}</h2>
+<form method="post" action="{{ url_for('quiz.submit_quiz', quiz_id=quiz.id) }}" class="form">
+  {% for q in questions %}
+    <div class="qblock">
+      <p><strong>Q{{ loop.index }}.</strong> {{ q.text }}</p>
+      <label><input type="radio" name="q{{ q.id }}" value="A"> A) {{ q.option_a }}</label><br>
+      <label><input type="radio" name="q{{ q.id }}" value="B"> B) {{ q.option_b }}</label><br>
+      <label><input type="radio" name="q{{ q.id }}" value="C"> C) {{ q.option_c }}</label><br>
+      <label><input type="radio" name="q{{ q.id }}" value="D"> D) {{ q.option_d }}</label>
+    </div>
+  {% endfor %}
+  <button class="btn" type="submit">Submit</button>
+</form>
+{% endblock %}


### PR DESCRIPTION
Closes #<issue-number>  <!-- replace with the Issue ID you just opened -->

## Summary
- Adds Quiz/Question/Attempt models (SQLite via Flask-SQLAlchemy)
- Routes:
  - GET /quiz → list quizzes
  - GET /quiz/<id> → take quiz
  - POST /quiz/<id>/submit → score + save Attempt
  - GET /quiz/result/<attempt_id> → show result
- Seeds a small demo quiz if none exist
- Text-only templates; keeps original chat flow untouched

## Why
Provides an assessment layer to validate learning, and a base for future analytics.

## Notes
- Backward compatible; existing chat routes unchanged
- Works without model.pkl (LLM-only mode still fine)
