### PR TITLE
feat(dashboard): student progress view (attempts, quizzes, avg score)

### DIFF
--- a/routes/dashboard.py
+++ b/routes/dashboard.py
@@ -1,0 +1,22 @@
+from flask import Blueprint, render_template
+from flask_login import login_required, current_user
+from models import Attempt, Quiz
+
+dash_bp = Blueprint('dash', __name__)
+
+@dash_bp.get('/')
+@login_required
+def student_dashboard():
+    attempts = Attempt.query.filter_by(user_id=current_user.id).all()
+    # aggregate simple stats
+    total_quizzes = len({a.quiz_id for a in attempts})
+    total_attempts = len(attempts)
+    avg_score = round(sum(a.score for a in attempts)/sum(a.total for a in attempts)*100, 1) if attempts else 0.0
+    latest = attempts[-5:] if attempts else []
+    quizzes = {q.id: q for q in Quiz.query.all()}
+    return render_template('dashboard_student.html',
+                           total_quizzes=total_quizzes,
+                           total_attempts=total_attempts,
+                           avg_score=avg_score,
+                           latest=latest,
+                           quizzes=quizzes)

--- a/templates/dashboard_student.html
+++ b/templates/dashboard_student.html
@@ -1,0 +1,24 @@
+{% extends "base.html" %}
+{% block content %}
+<h2>Dashboard</h2>
+<div class="cards">
+  <div class="card"><div class="card-num">{{ total_quizzes }}</div><div class="card-label">Quizzes taken</div></div>
+  <div class="card"><div class="card-num">{{ total_attempts }}</div><div class="card-label">Attempts</div></div>
+  <div class="card"><div class="card-num">{{ avg_score }}%</div><div class="card-label">Avg Score</div></div>
+</div>
+
+<h3>Recent attempts</h3>
+<table class="table">
+  <thead><tr><th>Quiz</th><th>Score</th></tr></thead>
+  <tbody>
+  {% for a in latest %}
+    <tr>
+      <td>{{ quizzes[a.quiz_id].title }}</td>
+      <td>{{ a.score }}/{{ a.total }}</td>
+    </tr>
+  {% else %}
+    <tr><td colspan="2">No attempts yet.</td></tr>
+  {% endfor %}
+  </tbody>
+</table>
+{% endblock %}


### PR DESCRIPTION
Closes #<dashboard-issue-number>

## Summary
- Adds /dashboard with:
  - Quizzes taken (distinct)
  - Total attempts
  - Average score (%)
  - Recent 5 attempts table
- Read-only view using Attempt + Quiz

## Notes
Text-only UI; no images. Backward compatible with existing chat & quiz routes.
