### PR TITLE
test(ci): add smoke tests and GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+on:
+  push:
+    branches: [ main, feat/**, fix/**, chore/**, docs/**, ci/** ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest
+      - name: Run tests
+        env:
+          OPENAI_API_KEY: "dummy"   # prevents accidental external calls
+        run: pytest -q

--- a/tests/test_app_smoke.py
+++ b/tests/test_app_smoke.py
@@ -1,0 +1,36 @@
+import os
+from unittest.mock import patch
+from app import create_app
+
+def client():
+    app = create_app()
+    app.config["TESTING"] = True
+    return app.test_client()
+
+def login(c, email="student@example.com", password="student"):
+    return c.post("/signin", data={"email": email, "password": password}, follow_redirects=True)
+
+def test_home():
+    c = client()
+    rv = c.get("/")
+    assert rv.status_code == 200
+
+def test_auth_and_chat_page():
+    c = client()
+    # guarded route redirects when not logged in
+    assert c.get("/chat/").status_code in (302, 401, 403)
+    # login works
+    assert login(c).status_code == 200
+    # now chat loads
+    assert c.get("/chat/").status_code == 200
+
+@patch("helper.send_gptnew", return_value="test-answer")
+def test_chat_ask(mock_llm):
+    c = client()
+    login(c)
+    rv = c.post("/chat/ask", json={"prompt": "hello"})
+    assert rv.status_code == 200
+    data = rv.get_json()
+    assert data["ok"] is True
+    assert data["answer"] == "test-answer"
+    mock_llm.assert_called_once()


### PR DESCRIPTION
## Summary
- Adds minimal smoke tests (home, auth, chat ask with LLM mocked)
- Adds GitHub Actions to run pytest on PRs/commits
- Prevents external API calls in CI

## Notes
Text-only; no behavior changes to app.
